### PR TITLE
- Expose oauth.Token.Extra data to the oauth2.Token layer.

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -65,10 +65,15 @@ type Tokens interface {
 	Refresh() string
 	IsExpired() bool
 	ExpiryTime() time.Time
+	ExtraData() map[string]string
 }
 
 type token struct {
 	oauth.Token
+}
+
+func (t *token) ExtraData() map[string]string {
+	return t.Extra
 }
 
 // Returns the access token.


### PR DESCRIPTION
There's data proved in Extra by some providers such as google that needs to be exposed to other Middleware and handlers. This proved access to that data.
