### PR TITLE
Fix build due to golang/oauth2 incompatibility

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -57,15 +57,10 @@ type Tokens interface {
 	Refresh() string
 	IsExpired() bool
 	ExpiryTime() time.Time
-	ExtraData() map[string]string
 }
 
 type token struct {
 	oauth2.Token
-}
-
-func (t *token) ExtraData() map[string]string {
-	return t.Extra
 }
 
 // Returns the access token.


### PR DESCRIPTION
golang/oauth2@0ae3d4edc99f765dc1513a9605aa96e82877a20a changes type of 
Token.Extra. So our ExtraData() broken, but it doesn't seem to be used, just
remove unused function to fix the build.
