### PR TITLE
Fix infinite recursion from 478a5ec

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -77,7 +77,7 @@ func (t *token) Expired() bool {
 	if t == nil {
 		return true
 	}
-	return t.Expired()
+	return t.Token.Expired()
 }
 
 // ExpiryTime returns the expiry time of the user's access token.


### PR DESCRIPTION
The token types in this project were changed to use the name Expired()
instead of IsExpired(), matching golang/oauth2. This was unfortunate,
since this use of an anonymous field's method relied on there not being
a name collision.
