### PR TITLE
Un-remove ExtraData

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -56,10 +56,15 @@ type Tokens interface {
 	Refresh() string
 	Expired() bool
 	ExpiryTime() time.Time
+	ExtraData(string) string
 }
 
 type token struct {
 	oauth2.Token
+}
+
+func (t *token) ExtraData(key string) string {
+	return t.Extra(key)
 }
 
 // Access returns the access token.


### PR DESCRIPTION
It was removed in 3eced323e6a648c9f968f497c4711719984477ef due to the
fact that the interface of Token.Extra of golang/oauth2 was changed.
This commit un-removes ExtraData with different interface than the
previous one due to the limitation of golang/oauth2.

Example of an application that depends of ExtraData;
- https://github.com/typester/gate/blob/master/authenticator.go#L68-L69
